### PR TITLE
Fix typo in ARRAY_UNIQ example description

### DIFF
--- a/docs/sql_reference/functions-reference/array/array-uniq.md
+++ b/docs/sql_reference/functions-reference/array/array-uniq.md
@@ -51,7 +51,7 @@ SELECT
 
 **Returns**: `2`
 
-In the example below, there are three differentu sernames across all of the elements of the given arrays. However, there are only two unique tuples, ('tonytaylor', 'ruthgill') and ('tonytaylor', 'ywilson').
+In the example below, there are three different usernames across all of the elements of the given arrays. However, there are only two unique tuples, ('tonytaylor', 'ruthgill') and ('tonytaylor', 'ywilson').
 
 ```sql
 SELECT


### PR DESCRIPTION
Same as https://github.com/firebolt-db/firebolt-db.github.io/pull/190