### PR TITLE
fix(examples): replace "my_account" name with "dev"

### DIFF
--- a/docs/Guides/managing-your-organization/managing-accounts.md
+++ b/docs/Guides/managing-your-organization/managing-accounts.md
@@ -22,7 +22,7 @@ Creating an account requires the org_admin role.
  To create an account using SQL, use the [`CREATE ACCOUNT`](../../sql_reference/commands/data-definition/create-account.md) statement. For example:
 
 ```sql
-CREATE ACCOUNT my_account WITH REGION = 'us-east-1';
+CREATE ACCOUNT dev WITH REGION = 'us-east-1';
 ```
 
 ### UI 
@@ -53,7 +53,7 @@ Editing an account requires the account_admin or org_admin role.
 To edit an existing account using SQL, use the [`ALTER ACCOUNT`](../../sql_reference/commands/data-definition/alter-account.md) statement. For example:
 
 ```sql
-ALTER ACCOUNT my_account RENAME TO my_dev_account;
+ALTER ACCOUNT dev RENAME TO staging;
 ```
 
 ### UI
@@ -76,7 +76,7 @@ Deleting an account requires the account_admin or org_admin role.
 To delete an existing account using SQL, use the [`DROP ACCOUNT`](../../sql_reference/commands/data-definition/drop-account.md) statement. For example:
 
 ```sql
-DROP ACCOUNT my_account;
+DROP ACCOUNT dev;
 ```
 
 ### UI

--- a/docs/Guides/query-data/using-the-api.md
+++ b/docs/Guides/query-data/using-the-api.md
@@ -69,7 +69,7 @@ curl http://api.app.firebolt.io/web/v3/account/<account name>/engineUrl
 -H 'Authorization: Bearer <access token>'
 ```
 
-**Example:** `https://api.app.firebolt.io/web/v3/account/my_account/engineUrl`
+**Example:** `https://api.app.firebolt.io/web/v3/account/my-account/engineUrl`
 
 **Response**
 
@@ -89,7 +89,7 @@ curl http://api.app.firebolt.io/web/v3/account/<account name>/resolve \
 -H 'Authorization: Bearer <access token>'
 ```
 
-**Example:** `https://api.app.firebolt.io/web/v3/account/my_account/resolve`   
+**Example:** `https://api.app.firebolt.io/web/v3/account/my-account/resolve`   
 
 **Response**
 

--- a/docs/sql_reference/commands/access-control/grant.md
+++ b/docs/sql_reference/commands/access-control/grant.md
@@ -46,8 +46,8 @@ GRANT USAGE ON DATABASE my_db TO user_role;
 
 ## Example 2
 
-The following command will grant USAGE permissions on all databases in the account "my_account" to the role "user_role".
+The following command will grant USAGE permissions on all databases in the account "dev" to the role "user_role".
 
 ```sql
-GRANT USAGE ANY DATABASE ON ACCOUNT my_account TO user_role;
+GRANT USAGE ANY DATABASE ON ACCOUNT dev TO user_role;
 ```

--- a/docs/sql_reference/commands/access-control/revoke.md
+++ b/docs/sql_reference/commands/access-control/revoke.md
@@ -46,8 +46,8 @@ REVOKE MODIFY ON DATABASE my_db FROM user_role;
 
 ## Example 2
 
-The following command will revoke USAGE permissions on all databases in the account "my_account" from the role "user_role".
+The following command will revoke USAGE permissions on all databases in the account "dev" from the role "user_role".
 
 ```sql
-REVOKE USAGE ANY DATABASE ON ACCOUNT my_account FROM user_role;
+REVOKE USAGE ANY DATABASE ON ACCOUNT dev FROM user_role;
 ```

--- a/docs/sql_reference/commands/data-definition/alter-account.md
+++ b/docs/sql_reference/commands/data-definition/alter-account.md
@@ -29,8 +29,8 @@ ALTER ACCOUNT <account_name> RENAME TO <new_account_name>;
 
 ## Example
 
-The following command will rename the "my_account" account to "my_dev_account".
+The following command will rename the "dev" account to "staging".
 
 ```sql
-ALTER ACCOUNT my_account RENAME TO my_dev_account;
+ALTER ACCOUNT dev RENAME TO staging;
 ```

--- a/docs/sql_reference/commands/data-definition/create-account.md
+++ b/docs/sql_reference/commands/data-definition/create-account.md
@@ -32,5 +32,5 @@ CREATE ACCOUNT [IF NOT EXISTS] <account_name>
 The following command will create an account in the US East (N. Virginia) region.
 
 ```sql
-CREATE ACCOUNT my_account WITH REGION = “us-east-1”
+CREATE ACCOUNT dev WITH REGION = “us-east-1”
 ```

--- a/docs/sql_reference/commands/data-definition/drop-account.md
+++ b/docs/sql_reference/commands/data-definition/drop-account.md
@@ -31,8 +31,8 @@ All engines in your accounts must be in a stopped state before running the `DROP
 
 ## Example
 
-The following command will delete the "my_account" account. 
+The following command will delete the "dev" account. 
 
 ```sql
-DROP ACCOUNT my_account
+DROP ACCOUNT dev
 ```


### PR DESCRIPTION
The account name must not contain any special characters other than hyphen.

I decided to replace "my_account" with "dev" rather than with "my-account", because the SQL indentifiers with hyphens need to be quoted, which would only add unnecessary noise to the examples.