### PR TITLE
Updated the system engine capacity list

### DIFF
--- a/docs/Guides/working-with-engines/system-engine.md
+++ b/docs/Guides/working-with-engines/system-engine.md
@@ -24,6 +24,7 @@ The system engine supports running the following commands:
 * Non-data-accessing [SELECT](../../sql_reference/commands/queries/select.md) queries like `SELECT CURRENT_TIMESTAMP()`
 * [SELECT](../../sql_reference/commands/queries/select.md) queries on some [information_schema](../../sql_reference/information-schema/information-schema-and-usage-views.md) views:
     * [information_schema.accounts](../../sql_reference/information-schema/accounts.md)
+    * [information_schema.applicable_roles](../../sql_reference/information-schema/applicable-roles.md)
     * [information_schema.columns](../../sql_reference/information-schema/columns.md)
     * [information_schema.databases](../../sql_reference/information-schema/databases.md)
     * [information_schema.engines](../../sql_reference/information-schema/engines.md)


### PR DESCRIPTION
Added `information_schema.applicable_roles` to the list of information schema views the system engine is allowed to query.