### PR TITLE
Fixed a typo in curl command

### DIFF
--- a/docs/Guides/managing-your-organization/service-accounts.md
+++ b/docs/Guides/managing-your-organization/service-accounts.md
@@ -70,7 +70,7 @@ Generating a new secret for your service account user replaces any previous secr
 4. Authenticate using the service account via Firebolt’s REST API, send the following request to receive an authentication token:
 
 ```bash
-curl POST --location 'https://id.app.firebolt.io/oauth/token' \
+curl -X POST --location 'https://id.app.firebolt.io/oauth/token' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'audience=https://api.firebolt.io' \


### PR DESCRIPTION
The `curl -X POST` was written as `curl POST`.