### PR TITLE
Updated create user parameters

### DIFF
--- a/docs/sql_reference/commands/access-control/create-user.md
+++ b/docs/sql_reference/commands/access-control/create-user.md
@@ -17,7 +17,7 @@ For more information, see [Managing users](../../../Guides/managing-your-organiz
 ```sql
 CREATE USER [ IF NOT EXISTS ] <user_name>  
 [ WITH 
-[ LOGIN_NAME = <login_name> | SERVICE_ACCOUNT_NAME = <service_account> ]
+[ LOGIN = <login_name> | SERVICE_ACCOUNT = <service_account> ]
 [ DEFAULT_DATABASE = <database_name> ]
 [ DEFAULT_ENGINE = <engine_name> ]
 [ ROLE = <role> ]
@@ -30,7 +30,7 @@ CREATE USER [ IF NOT EXISTS ] <user_name>
 | Parameter  | Description |
 | :--------- | :---------- |
 | `<user_name>`                              | The name of the user. The user name can be any string, and can also contain spaces and non-alpha-numeric characters such as exclamation points (!), percent signs (%), at signs(@), dot signs (.), underscore signs (_), minus signs (-), and asterisks (*). If the string contains spaces or non-alphanumeric characters, it must be enclosed in single or double quotes.  |
-| `<login_name>` | An optional parameter to specify the name of the login to link the user with. This cannot be used in conjunction with the SERVICE_ACCOUNT parameter - a user can be linked to a login OR a service account but not both. |
+| `<login>` | An optional parameter to specify the name of the login to link the user with. This cannot be used in conjunction with the SERVICE_ACCOUNT parameter - a user can be linked to a login OR a service account but not both. |
 | `<service_account>` | An optional parameter to specify the name of the service account to link the user with. This cannot be used in conjunction with the LOGIN_NAME parameter - a user can be linked to a login OR a service account but not both. |
 | `<database_name>`                      | An optional parameter to define a default database for the user (for future purposes). |
 | `<engine_name>` | An optional parameter to define a default engine for the user (for future purposes). |


### PR DESCRIPTION
The command parameters in the system engine has changed. `service_account_name` is now `service_account`, and `login_name` is just `login`.