### PR TITLE
Update validation rule for account name

### DIFF
--- a/docs/sql_reference/commands/data-definition/alter-account.md
+++ b/docs/sql_reference/commands/data-definition/alter-account.md
@@ -22,10 +22,10 @@ ALTER ACCOUNT <account_name> RENAME TO <new_account_name>;
 ## Parameters 
 {: .no_toc} 
 
-| Parameter | Description |
-| :--- | :--- |
-| `<account_name>` | The name of the account to be altered. |
-| `<new_account_name>` | The new name for the account. The account name must start with an alphabetic character and cannot contain spaces or special characters except for hyphens (-). |
+| Parameter | Description                                                                                                                                                            |
+| :--- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<account_name>` | The name of the account to be altered.                                                                                                                                 |
+| `<new_account_name>` | The new name for the account. The account name must start and end with an alphabetic character and cannot contain spaces or special characters except for hyphens (-). |
 
 ## Example
 

--- a/docs/sql_reference/commands/data-definition/create-account.md
+++ b/docs/sql_reference/commands/data-definition/create-account.md
@@ -22,9 +22,9 @@ CREATE ACCOUNT [IF NOT EXISTS] <account_name>
 ## Parameters 
 {: .no_toc} 
 
-| Parameter  | Description |
-| :--------- | :---------- |
-| `<account_name>`                              | The name of the account, must start with an alphabetic character and cannot contain spaces or special characters except for hyphens (-). |
+| Parameter  | Description                                                                                                                                                                                                                                                            |
+| :--------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<account_name>`                              | The name of the account, must start and end with an alphabetic character and cannot contain spaces or special characters except for hyphens (-).                                                                                                                       |
 | `<region>`                      | The region in which the account is configured. Choose the same region as the Amazon S3 bucket that contains data you ingest. See [Available AWS Regions](../../../Reference/available-regions.md) If not specified, `us-east-1` (US East (N. Virginia) is the default. |                                                                                                    
 
 ## Example


### PR DESCRIPTION
Adding `and end` to indicate that the account name must end with alphanumeric character.