### PR TITLE
Update create-fact-dimension-table.md

### DIFF
--- a/docs/sql_reference/commands/data-definition/create-fact-dimension-table.md
+++ b/docs/sql_reference/commands/data-definition/create-fact-dimension-table.md
@@ -64,6 +64,10 @@ Firebolt supports the column constraints shown below.
 {: .note}
 Note that nullable columns can not be used in Firebolt indexes (Primary, or Aggregating indexes).
 
+{: .note}
+Note that column default expressions are temporarily disabled starting from version 4.3.0.
+We are working on a new implementation of this feature and it will be re-enabled in the near future.
+
 ### Example&ndash;Creating a table with nulls and not nulls
 
 This example illustrates different use cases for column definitions and `INSERT` statements.


### PR DESCRIPTION
Column default expression feature is disabled starting from version 4.3.0. It currently exposes incompatible behavior as the rest of the system.

We are working on a new implementation of column default expressions. Once it's done, the feature will be re-enabled.

