### PR TITLE
Update localtimestamp.md

### DIFF
--- a/docs/sql_reference/functions-reference/date-and-time/localtimestamp.md
+++ b/docs/sql_reference/functions-reference/date-and-time/localtimestamp.md
@@ -2,8 +2,9 @@
 layout: default
 title: LOCALTIMESTAMP
 description: Reference material for LOCALTIMESTAMP function
-parent: SQL functions
 great_grand_parent: SQL reference
+grand_parent: SQL functions
+parent: Date and time functions
 ---
 
 # LOCALTIMESTAMP


### PR DESCRIPTION
Fix parent linkage of `localtimestamp` to make sure it appears in the navigation bar again 