### PR TITLE
Update rbac.md

### DIFF
--- a/docs/Guides/security/rbac.md
+++ b/docs/Guides/security/rbac.md
@@ -172,8 +172,8 @@ CREATE USER user2 WITH ROLE=role2;
 CREATE TABLE t (a int); -- executed by user1
 CREATE VIEW v AS SELECT * FROM t; -- executed by user1
 
-GRANT SELECT ON v TO role2;
-REVOKE SELECT ON t FROM role2;
+GRANT SELECT ON VIEW v TO role2;
+REVOKE SELECT ON TABLE t FROM role2;
 SELECT * FROM v; -- executed by user2, successfully
 
 REVOKE USAGE ON SCHEMA public FROM role1;


### PR DESCRIPTION
Update the SQL syntax that was missing

# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

# Documentation Checklist
- [ ] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [ ] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents

If this PR touches a function implementation (aggregate, scalar, or table-valued):
- [ ] I've made sure my documentation is aligned with [these](https://github.com/firebolt-analytics/firebolt-docs-staging/blob/gh-pages/.github/ISSUE_TEMPLATE/new-function-template.md) guidelines on function documentation 
- [ ] I've validated that the `parent` of my docs page is set correctly and the function shows up in the right category of the table of contents
- [ ] I've made sure that the function was added to the function glossary

