### PR TITLE
Add CNAME record for docs.firebolt.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.firebolt.io


### PR DESCRIPTION
# Description
This is a CNAME change necessary to replace the current main documentation subdomain.
