### PR TITLE
Minor Docs Fixes(Storage Pricing, Key Engine Concepts, Develop Space Icon)

### DIFF
--- a/docs/Guides/getting-started/get-started-load-data-wizard.md
+++ b/docs/Guides/getting-started/get-started-load-data-wizard.md
@@ -28,7 +28,7 @@ Use the following steps to register with Firebolt:
 {: .note}
 New accounts receive 600 Firebolt unit (FBU) credits ($200+) to get started exploring Firebolt’s capabilities.
 
-Firebolt’s billing is based on engine runtime, measured in seconds. AWS S3 storage costs are passed through at the rate of $23 per TB. Your cost depends primarily on which engines you use and how long those engines are running.
+Firebolt’s billing is based on engine runtime, measured in seconds. AWS S3 storage costs are passed through at the rate of $23 per TB per month. Your cost depends primarily on which engines you use and how long those engines are running.
 
 You can view your total cost in FBU up to the latest second and in $USD up to the latest day. For more information, see the following **Create a Database** section. For more information about costs, see [Data Warehouse Pricing](https://www.firebolt.io/pricing). If you need to buy additional credits, connect Firebolt with your AWS Marketplace account. For more information about AWS Marketplace, see the following section: [Registering through AWS Marketplace section](./get-started-next.md#register-through-the-aws-marketplace).
 

--- a/docs/Guides/getting-started/get-started-sql.md
+++ b/docs/Guides/getting-started/get-started-sql.md
@@ -29,7 +29,7 @@ To get started using Firebolt, begin by registering using the following steps:
 {: .note}
 New accounts receive 600 Firebolt unit (FBU) credits ($200+) to get started exploring Firebolt’s capabilities.
 
-Firebolt’s billing is based on engine runtime, measured in seconds. We also pass through AWS S3 storage costs at the rate of $23 per TB. The amount that you spend is dependent primarily on which engines you use and how long those engines are running.
+Firebolt’s billing is based on engine runtime, measured in seconds. We also pass through AWS S3 storage costs at the rate of $23 per TB per month. The amount that you spend is dependent primarily on which engines you use and how long those engines are running.
 
 You can view your total cost in FBU up to the latest second and in $USD up to the latest day. For more information, see the following **Create a Database** section. For more information about costs, see [Data Warehouse Pricing](https://www.firebolt.io/pricing). If you need to buy additional credits, connect Firebolt with your AWS Marketplace account. For more information about AWS Marketplace, see the following section: [Registering through AWS Marketplace section](./get-started-next.md#register-through-the-aws-marketplace).
 

--- a/docs/Guides/query-data/using-the-develop-workspace.md
+++ b/docs/Guides/query-data/using-the-develop-workspace.md
@@ -24,7 +24,7 @@ You can launch the space for a database by clicking the **Develop** icon from th
 
 **Starting the Develop Space for the last database you worked with**
 
-1.  Choose the **>_** icon from the left navigation pane.
+1.  Choose the **</>** icon from the left navigation pane.
 
     <img src="../../assets/images/develop_workspace_ex0.png" alt="drawing" width="70%"/>
 

--- a/docs/Overview/engine-fundamentals.md
+++ b/docs/Overview/engine-fundamentals.md
@@ -39,7 +39,7 @@ A cluster is a collection of compute resources, described by “Type” and “N
 <br />
 The three attributes-  Type, Nodes and Clusters - together form the configuration or topology of an engine.
 
-To create an engine, use the [CREATE ENGINE command](../sql_reference/commands/engines/create-engine.md), specifying the node type to be used for the engine, number of clusters and number of nodes per cluster. For example, the command below will create an engine with node type ‘S’,  one cluster and four nodes per cluster:
+To create an engine, use the [CREATE ENGINE command](../sql_reference/commands/engines/create-engine.md), specifying the node type to be used for the engine, number of clusters and number of nodes per cluster. For example, the command below will create two clusters, each containing four nodes of type  ‘M’.
 
 ```sql
 CREATE ENGINE IF NOT EXISTS MyEngine WITH


### PR DESCRIPTION
# Description
* The developer space Icon is different in the instructions than what is reflected in the UI (“Choose >_ icon from the left navigation pane[ https://docs.firebolt.io/Guides/query-data/using-the-develop-workspace.html#open-the-develop-space](https://docs.firebolt.io/Guides/query-data/using-the-develop-workspace.html#open-the-develop-space). 

* Key Engine Concepts documentation mention a node of Type S and one cluster, but the example provides a Node of type M & 2 Clusters:[ https://docs.firebolt.io/Overview/engine-fundamentals.html#key-engine-concepts](https://docs.firebolt.io/Overview/engine-fundamentals.html#key-engine-concepts). This PR rectifies that and makes it more inline with the example.

* Storage Pricing is made more clear adding that Storage costs are passed through at $23/TB per month

# When should this PR be released to the public?
**immediate release** 

# Documentation Checklist
- [x] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [x] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents



