### PR TITLE
fix: Remove non-existing connector mention from SQLAlchemy doc

### DIFF
--- a/docs/Guides/developing-with-firebolt/connecting-with-sqlalchemy.md
+++ b/docs/Guides/developing-with-firebolt/connecting-with-sqlalchemy.md
@@ -11,7 +11,7 @@ has_toc: true
 
 SQLAlchemy is an open-source SQL toolkit and object-relational mapper for the Python programming language.
 
-Firebolt’s adapter for SQLAlchemy acts as an interface for other supported third-party applications including Superset and Redash. When the SQLAlchemy adapter is successfully connected, these applications are able to communicate with Firebolt databases through the REST API.
+Firebolt’s adapter for SQLAlchemy acts as an interface for other supported third-party applications including Superset and Preset. When the SQLAlchemy adapter is successfully connected, these applications are able to communicate with Firebolt databases through the REST API.
 
 The adapter is written in Python using the SQLAlchemy toolkit.
 


### PR DESCRIPTION
# Description
We don't have Redash connector in Firebolt 2.0, we should remove mention of it to avoid confusing the customers.

# When should this PR be released to the public?
 **immediate release** 

# Documentation Checklist
- [x] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [x] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents

If this PR touches a function implementation (aggregate, scalar, or table-valued):
- [x] I've made sure my documentation is aligned with [these](https://github.com/firebolt-analytics/firebolt-docs-staging/blob/gh-pages/.github/ISSUE_TEMPLATE/new-function-template.md) guidelines on function documentation 
- [ ] I've validated that the `parent` of my docs page is set correctly and the function shows up in the right category of the table of contents
- [ ] I've made sure that the function was added to the function glossary

