### PR TITLE
Remove wrong note about non-nullability of PI

### DIFF
--- a/docs/sql_reference/commands/data-definition/create-fact-dimension-table.md
+++ b/docs/sql_reference/commands/data-definition/create-fact-dimension-table.md
@@ -67,9 +67,6 @@ Firebolt supports the column constraints shown below.
 | `NULL` \| `NOT NULL` | Determines if the column may or may not contain NULLs.                                                                                                                                                                     | `NOT NULL`    |
 
 {: .note}
-Note that nullable columns can not be used in Firebolt indexes (Primary, or Aggregating indexes).
-
-{: .note}
 Note that column default expressions are temporarily disabled starting from version 4.3.0.
 We are working on a new implementation of this feature and it will be re-enabled in the near future.
 


### PR DESCRIPTION
# Description
Remove wrong note about non-nullability of PI

# When should this PR be released to the public?
immediate release

# Documentation Checklist
- [ ] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [ ] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents

If this PR touches a function implementation (aggregate, scalar, or table-valued):
- [ ] I've made sure my documentation is aligned with [these](https://github.com/firebolt-analytics/firebolt-docs-staging/blob/gh-pages/.github/ISSUE_TEMPLATE/new-function-template.md) guidelines on function documentation 
- [ ] I've validated that the `parent` of my docs page is set correctly and the function shows up in the right category of the table of contents
- [ ] I've made sure that the function was added to the function glossary

