### PR TITLE
Fix inconsistencies in indexes documentation

### DIFF
--- a/docs/Guides/working-with-indexes/using-primary-indexes.md
+++ b/docs/Guides/working-with-indexes/using-primary-indexes.md
@@ -107,7 +107,7 @@ SELECT
 FROM
   players
 WHERE
-  UPPER(playerid) LIKE ‘AA%’;
+  UPPER(playerid) LIKE 'AA%';
 ```
 
 In contrast, Firebolt can use the primary index in the following example:
@@ -120,7 +120,7 @@ SELECT
 FROM
   players
 WHERE
-  playerid LIKE ‘AAA%’;
+  playerid LIKE 'AAA%';
 ```
 
 If you know that you will use a function in a predicate ahead of time, consider creating a column to store the result of the function. You can then use that column in your index and queries. This is particularly useful for hashing columns.
@@ -209,7 +209,7 @@ SELECT
 FROM
   players
 WHERE
-  EXTRACT(YEAR FROM registeredon) = ‘2021’
+  EXTRACT(YEAR FROM registeredon) = '2021'
 ```
 
 For both queries, the best primary index is:
@@ -319,5 +319,5 @@ SELECT
 FROM
   player_registry
 WHERE
-  upper_playerid LIKE ‘AAA%’;
+  upper_playerid LIKE 'AAA%';
 ```

--- a/docs/Guides/working-with-indexes/using-primary-indexes.md
+++ b/docs/Guides/working-with-indexes/using-primary-indexes.md
@@ -44,7 +44,7 @@ After you create a table, you can’t modify the primary index. To change the in
 ## How to choose primary index columns
 
 The columns that you choose for the primary index and the order in which you specify them are important.
-By choosing a good a primary index, scan sizes can be reduced drastically.
+By choosing a good primary index, scan sizes can be reduced drastically.
 This in turn leads to much faster query execution.
 
 If you have already defined a workload that you want to run in Firebolt, try out the [CALL RECOMMEND_DDL](../../sql_reference/commands/queries/recommend_ddl.html) command to find suitable primary index and partition key configurations. 
@@ -71,8 +71,8 @@ F3 sorts the data in dictionary order.
 If you define a primary index `(a, b)`, this means that the data blocks on S3 are ordered by `a`.
 Rows with the same values of `a` are consecutive and ordered by `b`.
 
-If column `a` has low cardinality (i.e. few distinct values) there will be long ordered runs of `b` in the F3 files.
-If column `a` has high cardinality (i.e. many distinct values), there will be almost no ordered runs of `b`.
+If column `a` has low cardinality, or few distinct values, there will be long ordered runs of `b` in the F3 files.
+If column `a` has high cardinality, or many distinct values, there will be almost no ordered runs of `b`.
 
 Firebolt's pruning is most effective on long runs of ordered data.
 To get good pruning for both `a` and `b`, it's important that `a` has few distinct values.
@@ -123,7 +123,7 @@ WHERE
   playerid LIKE ‘AAA%’;
 ```
 
-If you know that you will use a function in a predicate ahead of time, consider creating a virtual column to store the result of the function. You can then use that virtual column in your index and queries. This is particularly useful for hashing columns.
+If you know that you will use a function in a predicate ahead of time, consider creating a column to store the result of the function. You can then use that column in your index and queries. This is particularly useful for hashing columns.
 
 ### With a star schema, include join key columns in the fact table index
 
@@ -263,19 +263,17 @@ PRIMARY INDEX (playerid, asset_id, event_type)
 * The addition of `asset_id` won’t accelerate this particular query, but adding it is not detrimental.
 * Although `event_type` has low cardinality, because it’s contained in the `WHERE` clause, adding it to the primary index has some benefit.
 
-### Example&mdash;using virtual columns
+### Example&mdash;using columns
 
-Virtual columns are most often used in a primary index to:
+Columns are most often used in a primary index to:
 
 * Accommodate functions that alter column values.
 * Calculate hash values for columns that contain long strings.
 
-A virtual-column example for a function that transforms a column value is shown below.
-
-#### Step 1&mdash;create the fact table with the virtual column in the index
+#### Step 1&mdash;create the fact table with the column in the index
 {: .no_toc}
 
-The example DDL below creates a fact table similar to the one earlier in this section. However, it adds the `upper_playerid` column. The table creates this virtual column to store the result of an `UPPER` function that upper-cases `playerid` values during the `INSERT INTO` operation.
+The example DDL below creates a fact table similar to the one earlier in this section. However, it adds the `upper_playerid` column. The table creates this column to store the result of an `UPPER` function that upper-cases `playerid` values during the `INSERT INTO` operation.
 
 The `PRIMARY INDEX` clause uses the `upper_playerid` column because that column is used in analytics queries.
 
@@ -308,10 +306,10 @@ FROM
   players;
 ```
 
-#### Step 3&mdash;query using the virtual column in predicates
+#### Step 3&mdash;query using the column in predicates
 {: .no_toc}
 
-The example `SELECT` query below uses the virtual column to produce query results and benefits from the index.
+The example `SELECT` query below uses the column to produce query results and benefits from the index.
 
 ```sql
 SELECT

--- a/docs/Guides/working-with-indexes/using-primary-indexes.md
+++ b/docs/Guides/working-with-indexes/using-primary-indexes.md
@@ -275,20 +275,20 @@ A virtual-column example for a function that transforms a column value is shown 
 #### Step 1&mdash;create the fact table with the virtual column in the index
 {: .no_toc}
 
-The example DDL below creates a fact table similar to the one earlier in this section. However, it adds the `upper_customer_id` column. The table creates this virtual column to store the result of an `UPPER` function that upper-cases `customer_id` values during the `INSERT INTO` operation.
+The example DDL below creates a fact table similar to the one earlier in this section. However, it adds the `upper_playerid` column. The table creates this virtual column to store the result of an `UPPER` function that upper-cases `playerid` values during the `INSERT INTO` operation.
 
-The `PRIMARY INDEX` clause uses the `upper_customer_id` column because that column is used in analytics queries.
+The `PRIMARY INDEX` clause uses the `upper_playerid` column because that column is used in analytics queries.
 
 ```sql
-CREATE FACT TABLE events_log (
+CREATE FACT TABLE player_registry (
   visit_date DATE,
   asset_id TEXT,
-  customer_id TEXT NOT NULL,
+  playerid TEXT NOT NULL,
   event_type TEXT,
   event_count INTEGER NOT NULL,
-  uppder_customer_id TEXT NOT NULL
+  upper_playerid TEXT NOT NULL
 )
-PRIMARY INDEX visit_date, upper _customer_id;
+PRIMARY INDEX visit_date, upper_playerid;
 ```
 
 #### Step 2&mdash;use the function during ingestion (`INSERT INTO` statement)
@@ -298,12 +298,12 @@ PRIMARY INDEX visit_date, upper _customer_id;
 INSERT INTO
   player_registry 
 SELECT
-  registeredon,
+  visit_date,
   asset_id,
   playerid,
   event_type,
   event_count,
-  UPPER(playerid) AS upper_player_id
+  UPPER(playerid) AS upper_playerid
 FROM
   players;
 ```
@@ -317,7 +317,7 @@ The example `SELECT` query below uses the virtual column to produce query result
 SELECT
   playerid
 FROM
-  players
+  player_registry
 WHERE
-  upper_player_id LIKE ‘AAA%’;
+  upper_playerid LIKE ‘AAA%’;
 ```

--- a/docs/Guides/working-with-indexes/using-primary-indexes.md
+++ b/docs/Guides/working-with-indexes/using-primary-indexes.md
@@ -263,17 +263,19 @@ PRIMARY INDEX (playerid, asset_id, event_type)
 * The addition of `asset_id` won’t accelerate this particular query, but adding it is not detrimental.
 * Although `event_type` has low cardinality, because it’s contained in the `WHERE` clause, adding it to the primary index has some benefit.
 
-### Example&mdash;using columns
+### Example&mdash; query optimization using primary indexes for transformed column values
 
-Columns are most often used in a primary index to:
+You can include columns inside primary indexes to:
 
-* Accommodate functions that alter column values.
-* Calculate hash values for columns that contain long strings.
+* Optimize query performance by organizing data based on frequently filtered or joined columns.
+* Improve lookup efficiency for large datasets.
+
+The following example shows how to optimize queries using primary indexes that include transformed column values. 
 
 #### Step 1&mdash;create the fact table with the column in the index
 {: .no_toc}
 
-The example DDL below creates a fact table similar to the one earlier in this section. However, it adds the `upper_playerid` column. The table creates this column to store the result of an `UPPER` function that upper-cases `playerid` values during the `INSERT INTO` operation.
+The following code example creates a fact table with an `upper_playerid` column, which stores the result of an `UPPER` function that upper-cases `playerid` values during the `INSERT INTO` operation.
 
 The `PRIMARY INDEX` clause uses the `upper_playerid` column because that column is used in analytics queries.
 


### PR DESCRIPTION
# Description

Fix inconsistencies in indexes documentation. The table creation and insertion used completely different column names. Creation used `customer_id`, while insertion used `playerid`. Also, there was a typo in `uppder_customer_id` (extra `d`) and a space too much in `upper _customer_id`.

I went for `playerid` and `upper_playerid` because the other examples on the page use this name as well. Note that the other examples on the page are a bit inconsistent as well, but at least they are not step-by-step instructions like in this example on virtual columns.

> **Note:** 
> Apart from the inconsistency, there is another possible problem with that documentation section. The heading is "using virtual columns", but the table seems to only have normal columns, no virtual ones. The ingestion seems to explicitly convert and store the value when selecting `UPPER(playerid) AS upper_playerid`. In contrast, at least in other databases, the column should not be filled when inserting, but filled automatically by defining the column as something like `upper_playerid TEXT GENERATED ALWAYS AS (UPPER(playerid)) VIRTUAL` during table creation.
> This problem is independent of the naming inconsistencies and needs to be fixed by someone who knows the specific syntax you are using for creating virtual columns.

# When should this PR be released to the public?
immediate release

# Documentation Checklist
- [x] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [x] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents

If this PR touches a function implementation (aggregate, scalar, or table-valued):
- [ ] I've made sure my documentation is aligned with [these](https://github.com/firebolt-analytics/firebolt-docs-staging/blob/gh-pages/.github/ISSUE_TEMPLATE/new-function-template.md) guidelines on function documentation
  - **I'm getting a 404 on that link**
- [ ] I've validated that the `parent` of my docs page is set correctly and the function shows up in the right category of the table of contents
- [ ] I've made sure that the function was added to the function glossary

