### PR TITLE
Added 2 new columns in `information_schema.engines` table

### DIFF
--- a/docs/sql_reference/information-schema/engines.md
+++ b/docs/sql_reference/information-schema/engines.md
@@ -34,7 +34,9 @@ Each row has the following columns with information about each engine.
 | scale                       | INTEGER     | \[DEPRECATED\] The number of nodes in the engine. |
 | type                        | TEXT        | Determines the capability of the nodes in the engine. |
 | nodes                       | INTEGER     | The number of nodes in a cluster. |
-| clusters                    | INTEGER     | The number of node groupings in an engine. |
+| clusters                    | INTEGER     | The current number of node groupings in an engine. |
+| min_clusters                | INTEGER     | The minimum allowed number of node groupings in an engine. |
+| max_clusters                | INTEGER     | The maximum allowed number of node groupings in an engine. |
 | status                      | TEXT        | The engine status. For more information, see [Viewing and understanding engine status](../../Overview/engine-fundamentals.md#viewing-and-understanding-engine-status). |
 | attached_to                 | TEXT        | \[DEPRECATED\] The name of the database to which the engine is attached. |
 | auto_start                  | BOOLEAN     | When true, queries issued to a stopped engine will attempt to start the engine first. |


### PR DESCRIPTION
Added 2 new columns in `information_schema.engines` table that pertain to auto-scaling: `min_clusters bigint` and
'max_clusters bigint` (https://packboard.atlassian.net/browse/FIR-43706)

# Description

# When should this PR be released to the public?
I don't know yet in which version of packdb it will be released.

# Documentation Checklist
- [ ] I've previewed my documentation locally running `make start-local` (or using [this](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll) tutorial) 
- [ ] I've validated that indexing works and that I'm able to navigate to the documentation page from the table of contents

If this PR touches a function implementation (aggregate, scalar, or table-valued):
- [ ] I've made sure my documentation is aligned with [these](https://github.com/firebolt-analytics/firebolt-docs-staging/blob/gh-pages/.github/ISSUE_TEMPLATE/new-function-template.md) guidelines on function documentation 
- [ ] I've validated that the `parent` of my docs page is set correctly and the function shows up in the right category of the table of contents
- [ ] I've made sure that the function was added to the function glossary

