### PR TITLE
chore: Query timeout -> Statement timeout title

### DIFF
--- a/docs/Reference/system-settings.md
+++ b/docs/Reference/system-settings.md
@@ -63,8 +63,8 @@ SET standard_conforming_strings = true;
 SELECT '\x3132'; --> \x3132
 ```
 
-## Query timeout
-Specifies the number of milliseconds a query is allowed to run. Any statement or query exceeding the specified time is canceled. A value of zero disables the timeout by default.
+## Statement timeout
+Specifies the number of milliseconds a SQL statement is allowed to run. Any SQL statement or query exceeding the specified time is canceled. A value of zero disables the timeout by default.
 
 ### Syntax
 {: .no_toc}


### PR DESCRIPTION
# Description
We had user who got confused and used `query_timeout` instead of  `statement_timeout` because the heading said "Query timeout". So let's make it consistent.

# When should this PR be released to the public?
In live prod

